### PR TITLE
Select single legend

### DIFF
--- a/R/plot_importance_plot.R
+++ b/R/plot_importance_plot.R
@@ -120,7 +120,10 @@ plot.importance_plot <- function(x, plot = TRUE, nvar = NA,
       grDevices::dev.off()
 
     # extract the legend
-    legend_grob <- ggp2_grob$grobs[[which(ggp2_grob$layout$name == "guide-box")]]
+    legend_grob <- ggp2_grob$grobs[grepl("guide-box", ggp2_grob$layout$name)]
+    select <- which(!vapply(legend_grob, inherits, logical(1), "zeroGrob"))[1]
+    legend_grob <- legend_grob[[select]]
+
     # blank grob
     r <- grid::rectGrob(gp = grid::gpar(fill = NA, col = NA))
     # height of legend


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break tornado.

In the new version, a plot can have multiple legend guide boxes, so the extracton method in the importance plot no longer works. This PR updates the function to deal with multiple legends, selecting the first that isn't empty.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help tornado get out a fix if necessary.
